### PR TITLE
Basic Makefile that should work on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+CC=g++
+RM=rm -f
+CXXFLAGS+=-std=c++11
+LIBS=-lallegro -lallegro_font -lallegro_image -lallegro_primitives -lallegro_ttf
+LDFLAGS+=
+
+SOURCEDIR=src
+SOURCES=$(shell find $(SOURCEDIR) -name '*.cpp')
+OBJECTS=$(SOURCES:.cpp=.o)
+EXEC=vinctus-arce
+
+all: $(SOURCES) $(EXEC)
+
+$(EXEC): $(OBJECTS)
+	$(CC) $(LIBS) $(LDFLAGS) $(OBJECTS) -o $@
+
+%.o: %.cpp
+	$(CC) -c $(CXXFLAGS) $< -o $@
+
+clean:
+	$(RM) $(OBJECTS) $(EXEC)


### PR DESCRIPTION
Based on http://www.puxan.com/web/blog/HowTo-Write-Generic-Makefiles

It should work fine on Linux systems, but probably not out of the box on Windows
since it presupposes g++ as C++ compiler, and uses a Unix shell function to list
all *.cpp files recursively. It can most likely be improved later on to also work
for other systems though, if someone has the knowledge to do it.
